### PR TITLE
Update Paginator perPage

### DIFF
--- a/src/Support/ConnectionResolver.php
+++ b/src/Support/ConnectionResolver.php
@@ -41,7 +41,7 @@ class ConnectionResolver
         return new Paginator(
             $items,
             count($items),
-            count($items)
+            (count($items) > 0 ? count($items) : 1)
         );
     }
 


### PR DESCRIPTION
The perPage parameter for the Paginator was being set to 0 which triggered a division by zero error in the Paginator instantiation logic when resolving a relationship connection that had zero related objects. Set the perPage value to 1 instead which has no specific significance since there are no items in the paginator anyways